### PR TITLE
Add one tab indent

### DIFF
--- a/jernl.tmLanguage
+++ b/jernl.tmLanguage
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>items</string>
 			<key>match</key>
-			<string>^(\s\s&gt; ).+</string>
+			<string>^((\s{2}|\t)&gt; ).+</string>
 			<key>name</key>
 			<string>support.function.jernl</string>
 		</dict>


### PR DESCRIPTION
## Description

Now users can to see syntax highlighting if they press <kbd>Tab</kbd> key one time, not two time. I save also your indentation, see result: https://regex101.com/r/Ln9GOG/1.

---
## Reason
1. One press vs two press — time savings.
2. One tab [by default](http://editorconfig.org/) equivalent to 4 spaces. I think, 4 — good indentation. By default, I can use indentations 2 — two spaces and 8 — two tabs. For me, the default indentation is not good: 2 — small, 8 — big.

---

Thanks.
